### PR TITLE
Modify connect method in Client class

### DIFF
--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -25,7 +25,7 @@ public class Client {
   private User user;
   private JSch jsch;
   private Session session;
-  private ChannelSftp cSftp;
+  private ChannelSftp channelSftp;
   private Logger logger;
 
   /** Class constructor. */
@@ -33,7 +33,7 @@ public class Client {
     user = new User();
     jsch = new JSch();
     session = null;
-    cSftp = new ChannelSftp();
+    channelSftp = new ChannelSftp();
   }
 
   /**
@@ -48,7 +48,7 @@ public class Client {
     user = new User(username, password, hostname);
     jsch = new JSch();
     session = null;
-    cSftp = new ChannelSftp();
+    channelSftp = new ChannelSftp();
   }
 
   /** Prompts the user to enter connection information such as username, password, and hostname. */
@@ -58,36 +58,77 @@ public class Client {
     user.getHostname();
   }
 
-  /** Initiates connection */
-  boolean connect() {
-    logger = new Logger();
+  /**
+   * Establishes a connection to an SSH server containing a channel connected to an SFTP server.
+   *
+   * @return <code>true</code> on successful connection to the SSH/SFTP server; <code>false</code>
+   *     otherwise.
+   */
+  public boolean connect() {
+    if (createSshConnection() && createSftpChannel()) {
+      logger.log("Successfully connected to the SSH/SFTP server");
+      out.println("Successfully connected to the SSH/SFTP server");
+      return true;
+    } else {
+      out.println("Failed to connect to the server");
+      logger.log("Error occurred when attempting to connect to the SSH/SFTP server");
+      return false;
+    }
+  }
+
+  /**
+   * Creates a session, which represents a connection to an SSH server.
+   *
+   * <p>One session can contain multiple channels of various types.
+   *
+   * @return <code>true</code> on successful creation of session object representing a connection to
+   *     an SSH server; <code>false</code> otherwise.
+   */
+  protected boolean createSshConnection() {
     try {
       session = jsch.getSession(user.username, user.hostname, 22);
       session.setPassword(user.password);
       Properties config = new Properties();
+      // Do not verify public key of the SSH/SFTP server; connecting within a trusted network
       config.put("StrictHostKeyChecking", "no");
       session.setConfig(config);
-      logger.log("Establishing connection for " + user.username + "@" + user.hostname + "...");
-      out.println("Establishing Connection...");
       session.connect(TIMEOUT);
+      logger.log(
+          String.format("Establishing a connection for %s @ %s...", user.username, user.hostname));
+      out.println("Establishing a connection...");
+    } catch (JSchException e) {
+      out.println("Failed to connect to the server");
+      logger.log("Exception occurred when attempting to connect to the SSH server");
+      return false;
+    }
+    return true;
+  }
 
+  /**
+   * Creates a channel connected to an SFTP server (as a subsystem of the SSH server), which
+   * supports the client side of the SFTP protocol.
+   *
+   * @return <code>true</code> on creating a channel connected to an SFTP server; <code>false</code>
+   *     otherwise.
+   */
+  protected boolean createSftpChannel() {
+    try {
       Channel channel = session.openChannel("sftp");
       channel.setInputStream(null);
       channel.connect(TIMEOUT);
-      cSftp = (ChannelSftp) channel;
+      channelSftp = (ChannelSftp) channel;
+      logger.log("Establishing a connection to the SFTP server");
     } catch (JSchException e) {
-      out.println("Connection failed.");
+      out.println("Failed to establish the SFTP connection");
+      logger.log("Exception occurred when attempting to connect to the SFTP server");
       return false;
     }
-
-    logger.log("Successful SFTP connection made");
-    out.println("Successful SFTP connection");
     return true;
   }
 
   /** Terminates connection */
   void disconnect() {
-    cSftp.exit();
+    channelSftp.exit();
     session.disconnect();
     logger.log("SFTP connection closed");
     logger.save(user.username + "@" + user.hostname);
@@ -98,8 +139,8 @@ public class Client {
    *
    * @return -- returns the cSftp object.
    */
-  ChannelSftp getcSftp() {
-    return cSftp;
+  ChannelSftp getChannelSftp() {
+    return channelSftp;
   }
 
   /**
@@ -114,7 +155,7 @@ public class Client {
   /** Lists all directories and files on the user's local machine (from the current directory). */
   int displayLocalFiles() {
     logger.log("displayLocalFiles called");
-    File dir = new File(cSftp.lpwd());
+    File dir = new File(channelSftp.lpwd());
     printLocalWorkingDir();
     File[] files = dir.listFiles();
     if (files != null) {
@@ -138,7 +179,7 @@ public class Client {
 
     try {
       printRemoteWorkingDir();
-      Vector remoteDir = cSftp.ls(cSftp.pwd());
+      Vector remoteDir = channelSftp.ls(channelSftp.pwd());
       if (remoteDir != null) {
         int count = 0;
         for (int i = 0; i < remoteDir.size(); ++i) {
@@ -172,7 +213,7 @@ public class Client {
       out.println("Enter the name of the new directory: ");
       dirName = scanner.next();
       try {
-        attrs = cSftp.stat(dirName);
+        attrs = channelSftp.stat(dirName);
       } catch (Exception e) {
         out.println("A directory by this name doesn't exist, it will now be created.");
       }
@@ -182,7 +223,7 @@ public class Client {
         attrs = null; // reset attrs for loop
         if (answer.equalsIgnoreCase("yes")) {
           try {
-            cSftp.rmdir(dirName);
+            channelSftp.rmdir(dirName);
             if (createRemoteDir(dirName)) out.println(dirName + " has been overwritten");
             repeat = false;
           } catch (SftpException e) {
@@ -204,8 +245,8 @@ public class Client {
   boolean createRemoteDir(String dirName) {
     SftpATTRS attrs = null;
     try {
-      cSftp.mkdir(dirName);
-      attrs = cSftp.stat(dirName);
+      channelSftp.mkdir(dirName);
+      attrs = channelSftp.stat(dirName);
     } catch (Exception e) {
       out.println("Error creating directory.");
     }
@@ -215,14 +256,14 @@ public class Client {
   /** Print current working local path */
   void printLocalWorkingDir() {
     logger.log("printLocalWorkingDir called");
-    String lpwd = cSftp.lpwd();
+    String lpwd = channelSftp.lpwd();
     out.println("This is your current local working directory: " + lpwd + "\n");
   }
 
   /** Print current working remote path */
   void printRemoteWorkingDir() throws SftpException {
     logger.log("printRemoteWorkingDir called");
-    String pwd = cSftp.pwd();
+    String pwd = channelSftp.pwd();
     out.println("This is your current remote working directory: " + pwd + "\n");
   }
 
@@ -230,12 +271,12 @@ public class Client {
   void changeLocalWorkingDir() {
     logger.log("changeLocalWorkingDir called");
     String newDir;
-    String lpwd = cSftp.lpwd();
+    String lpwd = channelSftp.lpwd();
     out.println("This is your current local working directory: " + lpwd + "\n");
     out.println("Enter the path of the directory you'd like to change to: ");
     newDir = scanner.next();
     if (changeLocalWorkingDir(newDir)) {
-      lpwd = cSftp.lpwd();
+      lpwd = channelSftp.lpwd();
       out.println("This is your new current local working directory: " + lpwd + "\n");
     }
   }
@@ -249,7 +290,7 @@ public class Client {
   boolean changeLocalWorkingDir(String newDir) {
     boolean pass = false;
     try {
-      cSftp.lcd(newDir);
+      channelSftp.lcd(newDir);
       pass = true;
     } catch (SftpException e) {
       out.println("Error changing your directory");
@@ -261,11 +302,11 @@ public class Client {
   void changeRemoteWorkingDir() throws SftpException {
     logger.log("changeRemoteWorkingDir called");
     String newDir;
-    out.println("This is your current remote working directory: " + cSftp.pwd() + "\n");
+    out.println("This is your current remote working directory: " + channelSftp.pwd() + "\n");
     out.println("Enter the path of the directory you'd like to change to: ");
     newDir = scanner.next();
     if (changeRemoteWorkingDir(newDir))
-      out.println("This is your new current remote working directory: " + cSftp.pwd() + "\n");
+      out.println("This is your new current remote working directory: " + channelSftp.pwd() + "\n");
   }
 
   /**
@@ -276,7 +317,7 @@ public class Client {
   boolean changeRemoteWorkingDir(String newDirPath) {
     boolean pass = false;
     try {
-      cSftp.cd(newDirPath);
+      channelSftp.cd(newDirPath);
       pass = true;
     } catch (SftpException e) {
       System.out.println("Error changing your directory");
@@ -299,10 +340,10 @@ public class Client {
       // take the string and separate out the files.
       String removeWhitespace = filename.replaceAll("\\s", "");
       String[] arr = removeWhitespace.split(",");
-      String pwd = cSftp.pwd();
+      String pwd = channelSftp.pwd();
       StringBuilder sb = new StringBuilder();
       for (String file : arr) {
-        cSftp.put(file, file);
+        channelSftp.put(file, file);
         sb.append(file);
         sb.append(" has been uploaded to: ");
         sb.append(pwd);
@@ -311,8 +352,8 @@ public class Client {
       String output = sb.toString();
       out.println(output);
     } else {
-      cSftp.put(filename, filename);
-      String pwd = cSftp.pwd();
+      channelSftp.put(filename, filename);
+      String pwd = channelSftp.pwd();
       out.println(filename + " has been uploaded to: " + pwd);
     }
   }
@@ -332,10 +373,10 @@ public class Client {
       // take the string and separate out the files.
       String removeWhitespace = filename.replaceAll("\\s", "");
       String[] arr = removeWhitespace.split(",");
-      String lpwd = cSftp.lpwd();
+      String lpwd = channelSftp.lpwd();
       StringBuilder sb = new StringBuilder();
       for (String file : arr) {
-        cSftp.get(file, file);
+        channelSftp.get(file, file);
         sb.append(file);
         sb.append(" has been downloaded to: ");
         sb.append(lpwd);
@@ -344,8 +385,8 @@ public class Client {
       String output = sb.toString();
       out.println(output);
     } else {
-      cSftp.get(filename, filename);
-      String lpwd = cSftp.lpwd();
+      channelSftp.get(filename, filename);
+      String lpwd = channelSftp.lpwd();
       out.println("The file has been downloaded to: " + lpwd);
     }
   }
@@ -363,7 +404,7 @@ public class Client {
         if (oldFilename.equals("")) // check for empty input
         System.err.println("You did not enter a file name.");
       }
-      File originalFile = new File(cSftp.lpwd() + "/" + oldFilename);
+      File originalFile = new File(channelSftp.lpwd() + "/" + oldFilename);
       // get the new file name
       String newFilename = "";
       while (newFilename.equals("")) {
@@ -372,7 +413,7 @@ public class Client {
         if (newFilename.equals("")) // check for empty input
         System.err.println(("You did not enter a file name."));
       }
-      File renamedFile = new File(cSftp.lpwd() + "/" + newFilename);
+      File renamedFile = new File(channelSftp.lpwd() + "/" + newFilename);
       // check for a duplicate file/directory name
       boolean rename = false;
       if (renamedFile.exists()) {
@@ -449,7 +490,7 @@ public class Client {
         if (oldFilename.equals("")) // check for empty input
         System.err.println("You did not enter a file name.");
       }
-      String oldFilePath = cSftp.pwd() + "/" + oldFilename;
+      String oldFilePath = channelSftp.pwd() + "/" + oldFilename;
       // get the new file name
       String newFilename = "";
       while (newFilename.equals("")) {
@@ -458,9 +499,9 @@ public class Client {
         if (newFilename.equals("")) // check for empty input
         System.err.println(("You did not enter a file name."));
       }
-      String newFilePath = cSftp.pwd() + "/" + newFilename;
+      String newFilePath = channelSftp.pwd() + "/" + newFilename;
       try {
-        attrs = cSftp.stat(newFilePath);
+        attrs = channelSftp.stat(newFilePath);
       } catch (Exception e) {
         out.println();
       }
@@ -475,7 +516,7 @@ public class Client {
       }
       if (rename) {
         try {
-          cSftp.rename(oldFilePath, newFilePath);
+          channelSftp.rename(oldFilePath, newFilePath);
           out.println(oldFilename + " has been renamed to: " + newFilename);
         } catch (SftpException e) {
           out.println("Error: rename unsuccessful.");
@@ -495,7 +536,7 @@ public class Client {
     while (repeat) {
       out.println("Enter the name of the new directory: ");
       dirName = scanner.next();
-      String path = cSftp.lpwd() + "/" + dirName;
+      String path = channelSftp.lpwd() + "/" + dirName;
       File newDir = new File(path);
       if (newDir.exists()) { // directory exists
         out.println("A directory by this name exists. Overwrite? (yes/no)");
@@ -551,10 +592,10 @@ public class Client {
       String[] arr = removeWhitespace.split(",");
       String output = "";
       try {
-        pwd = cSftp.pwd();
+        pwd = channelSftp.pwd();
         StringBuilder sb = new StringBuilder();
         for (String file : arr) {
-          cSftp.rm(file);
+          channelSftp.rm(file);
           sb.append(file);
           sb.append(" has been deleted from:");
           sb.append(pwd);
@@ -568,8 +609,8 @@ public class Client {
       out.println(output);
     } else {
       try {
-        cSftp.rm(files);
-        pwd = cSftp.pwd();
+        channelSftp.rm(files);
+        pwd = channelSftp.pwd();
         out.println("The file has been deleted from: " + pwd);
       } catch (Exception e) {
         out.println("Error deleting remote files.");

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -21,7 +21,9 @@ import static java.lang.System.out;
  */
 public class Client {
   private Scanner scanner = new Scanner(System.in);
-  private static final int TIMEOUT = 10000;
+  private static final int TIMEOUT =
+      60_000; // Set default timeout to 60 seconds to accommodate slow servers
+  // private static final Logger LOGGER = Logger.getLogger(Client.class.getName());
   private User user;
   private JSch jsch;
   private Session session;

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -44,8 +44,8 @@ public class Client {
    * @param password the input containing the user's password
    * @param hostname the hostname specified by the user (e.g. linux.cs.pdx.edu)
    */
-  public Client(String password, String hostName, String userName) {
-    user = new User(password, hostName, userName);
+  public Client(String username, String password, String hostname) {
+    user = new User(username, password, hostname);
     jsch = new JSch();
     session = null;
     cSftp = new ChannelSftp();

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -28,7 +28,7 @@ public class Client {
   private ChannelSftp cSftp;
   private Logger logger;
 
-  /** Class constructor */
+  /** Class constructor. */
   public Client() {
     user = new User();
     jsch = new JSch();
@@ -37,12 +37,12 @@ public class Client {
   }
 
   /**
-   * A constructor taking username, password and hostname to facilitate creating a connection
-   * quickly.
+   * Class constructor specifying the username, password, and hostname required to create a
+   * connection to the server.
    *
-   * @param password -- Your password
-   * @param hostName -- Your host
-   * @param userName -- Your username
+   * @param username the input containing the user's login name
+   * @param password the input containing the user's password
+   * @param hostname the hostname specified by the user (e.g. linux.cs.pdx.edu)
    */
   public Client(String password, String hostName, String userName) {
     user = new User(password, hostName, userName);
@@ -51,7 +51,7 @@ public class Client {
     cSftp = new ChannelSftp();
   }
 
-  /** Prompts for connection information */
+  /** Prompts the user to enter connection information such as username, password, and hostname. */
   void promptConnectionInfo() {
     user.getUsername();
     user.getPassword();

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -23,7 +23,6 @@ public class Client {
   private Scanner scanner = new Scanner(System.in);
   private static final int TIMEOUT =
       60_000; // Set default timeout to 60 seconds to accommodate slow servers
-  // private static final Logger LOGGER = Logger.getLogger(Client.class.getName());
   private User user;
   private JSch jsch;
   private Session session;

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -99,7 +99,7 @@ public class ClientTest {
       assert(false);
     }
     client.uploadFile(fileName);
-    attrs = client.getcSftp().stat(fileName);
+    attrs = client.getChannelSftp().stat(fileName);
     if (attrs != null)
       pass = true;
     System.out.println("Now deleting the files you uploaded.");
@@ -128,7 +128,7 @@ public class ClientTest {
     client.uploadFile(fileName);
     System.out.println("Now deleting the files you uploaded.");
     client.deleteRemoteFile(fileName);
-    attrs = client.getcSftp().stat(fileName);
+    attrs = client.getChannelSftp().stat(fileName);
   }
 
   /**
@@ -177,7 +177,7 @@ public class ClientTest {
         client.downloadFile(fileName);
         client.downloadFile(fileName2);
         //verify that the file is in the local directory
-        File dir = new File(client.getcSftp().lpwd());
+        File dir = new File(client.getChannelSftp().lpwd());
         File[] files = dir.listFiles();
         for (File file : files) {
           if (file.getName().equals(fileName)) {
@@ -210,7 +210,7 @@ public class ClientTest {
     String dirName = "newDirectory";
     assertThat(client.createRemoteDir(dirName), equalTo(true));
     System.out.println(dirName + " was created successfully");
-    client.getcSftp().rmdir(dirName);        //clean up
+    client.getChannelSftp().rmdir(dirName);        //clean up
   }
 
   /**
@@ -224,7 +224,7 @@ public class ClientTest {
       assert(false);
     }
     String dirName = "newDirectory";
-    String path = client.getcSftp().lpwd() + "/" + dirName;
+    String path = client.getChannelSftp().lpwd() + "/" + dirName;
     File newDir = new File(path);
     assertThat(client.createLocalDir(newDir), equalTo(true));
     System.out.println(dirName + " was created successfully");
@@ -303,7 +303,7 @@ public class ClientTest {
       client.changeRemoteWorkingDir("..");       //reset path
       System.setOut(stdout);    //reset output to standard System.out
 
-      client.getcSftp().rmdir(newRemotePath);
+      client.getChannelSftp().rmdir(newRemotePath);
       System.out.println("Path successfully changed to new dir. New dir has been deleted and path is reset.");
       pass = true;
     } else {
@@ -352,7 +352,7 @@ public class ClientTest {
       System.setOut(new PrintStream(output));   //Redirect printstream
       client.displayRemoteFiles();
       assertThat(output.toString(), containsString(dirName));   //Assert output contains new dir
-      client.getcSftp().rmdir(dirName);        //clean up
+      client.getChannelSftp().rmdir(dirName);        //clean up
       System.setOut(stdout);      //Reset printstream to System.out
       System.out.println("New remote file successfully displayed. New dir has been deleted.");
       pass = true;

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -17,9 +17,9 @@ public class ClientTest {
   /**
    * These need to be filled in before the tests will run properly.
    */
-  private String userName = "u";
+  private String username = "u";
   private String password = "p";
-  private String hostName = "h";
+  private String hostname = "h";
 
   // TODO
   @Test
@@ -35,7 +35,7 @@ public class ClientTest {
    */
   @Test
   public void connection_assertsSuccessfulConnection() {
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     assertThat(client.connect(), equalTo(true));
   }
 
@@ -44,7 +44,7 @@ public class ClientTest {
    */
   @Test
   public void connection_wrongCredentials_expectsSftpException() {
-    Client client = new Client("fakepw", "fakehn", "fakeun");
+    Client client = new Client("fakeUsername", "fakePassword", "fakeHostname");
     assertThat(client.connect(), equalTo(false));
   }
 
@@ -53,7 +53,7 @@ public class ClientTest {
    */
   @Test(expected = SftpException.class)
   public void uploadFakeFile_expectsSftpException() throws SftpException {
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client("fakeUsername", "fakePassword", "fakeHostname");
     if(!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
       assert(false);
@@ -70,7 +70,7 @@ public class ClientTest {
   public void uploadFile_expectsSftpException_NoSuchFile() throws SftpException {
     String fileName = "MissingTextFile.txt";
 
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     if(!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
       assert(false);
@@ -93,7 +93,7 @@ public class ClientTest {
     boolean pass = false;
     SftpATTRS attrs;
 
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     if(!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
       assert(false);
@@ -119,7 +119,7 @@ public class ClientTest {
     String fileName = "testfile.txt";
     SftpATTRS attrs = null;
 
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     if(!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
       assert(false);
@@ -136,7 +136,7 @@ public class ClientTest {
    */
   @Test
   public void downloadFakeFile() {
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     try {
       if(!client.connect()) {
         System.out.println("Failed connection. Unable to run test.");
@@ -165,7 +165,7 @@ public class ClientTest {
     String fileName = "testfile.txt";
     String fileName2 = "testfile.txt, testfile2.txt";
 
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     try {
       if(!client.connect()) {
         System.out.println("Failed connection. Unable to run test.");
@@ -201,7 +201,7 @@ public class ClientTest {
    */
   @Test
   public void createRemoteDir_assertsDirExists() throws SftpException {
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     if(!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
       assert(false);
@@ -218,7 +218,7 @@ public class ClientTest {
    */
   @Test
   public void createLocalDir_assertsDirExists() {
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     if(!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
       assert(false);
@@ -244,7 +244,7 @@ public class ClientTest {
     String newLocalPath = "newLocalPath";
     File newDir = new File(newLocalPath);
 
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     if(!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
       assert(false);
@@ -285,7 +285,7 @@ public class ClientTest {
     PrintStream stdout = System.out;
     String newRemotePath = "newRemotePath";
 
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     if(!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
       assert(false);
@@ -320,7 +320,7 @@ public class ClientTest {
   @Test
   public void disconnect_assertsSessionIsDisconnected() {
     boolean pass = false;
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     if (client.connect()) {
       System.out.println("Now disconnecting your session...");
       client.disconnect();
@@ -342,7 +342,7 @@ public class ClientTest {
     String dirName = "newDirectory";
     boolean pass = false;
 
-    Client client = new Client(password, hostName, userName);
+    Client client = new Client(username, password, hostname);
     if (!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
       assert(false);


### PR DESCRIPTION
### Overview 
Completed my analysis of the constructors and the `connect()` method in the Client class (please take a look at my review first). Readability can be subjective, so please don't hesitate to start a dialogue if you think the modified code is _less_ clear in any way. 

Modifications to the Client class include:
* **Increased value of `TIMEOUT` field to 60_000 (60 seconds)**
* **Changed the logical order of arguments in the Client constructor**
  * Also updated this change in every place the constructor is referenced (including tests)
* **Deconstructed `connect()` method**
  * Added `createSshConnection()` utility method to handle SSH connection
  * Added `createSftpChannel()` utility method to handle SFTP connection
  * Kept `boolean` return values to avoid breaking unit tests
* **Changed variable name from `cSftp` to `channelSftp`**

At first, I did switch the custom Logger class to Java's utility Logger class (`private static final Logger LOGGER = Logger.getLogger(Client.class.getName());`) and incorporated log levels such as `INFO`, `SEVERE` to indicate the level of impact it had on the application. However, since this is a command line program, the logger will produce the following output: 

<img width="484" alt="Screen Shot 2020-02-23 at 6 28 18 PM" src="https://user-images.githubusercontent.com/23347186/75126522-2f1cda00-566f-11ea-8567-9a73a4691d74.png">

I think it's probably better (for this application) to stick with the custom Logger class, which redirects the logs to a file. I don't think it would be good practice to reveal our implementation details to the user. I wanted to point this out in case anyone else was wondering why we had a custom Logger class in the first place. 