### PR TITLE
Modify deleteRemoteFile method in Client class

### DIFF
--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -35,6 +35,7 @@ public class Client {
     jsch = new JSch();
     session = null;
     channelSftp = new ChannelSftp();
+    logger = new Logger();
   }
 
   /**
@@ -50,6 +51,7 @@ public class Client {
     jsch = new JSch();
     session = null;
     channelSftp = new ChannelSftp();
+    logger = new Logger();
   }
 
   /** Prompts the user to enter connection information such as username, password, and hostname. */

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -584,7 +584,7 @@ public class Client {
    * Deletes the specified file(s) from the remote server. Multiple file names can be included through a comma-separated
    * list.
    *
-   * @param filename The string containing the name(s) of the file(s) to be deleted.
+   * @param filename the string containing the name(s) of the file(s) to be deleted.
    */
   void deleteRemoteFile(String filename) {
     String workingDir;

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -581,41 +581,33 @@ public class Client {
   }
 
   /**
-   * Deletes specified the file(s) from the remote server. Multiple file names can be included through a comma-separated
+   * Deletes the specified file(s) from the remote server. Multiple file names can be included through a comma-separated
    * list.
    *
    * @param filename The string containing the name(s) of the file(s) to be deleted.
    */
-  void deleteRemoteFile(String files) {
-    String pwd;
-    if (files.contains(",")) {
-      // multiple files are wanted.
-      // take the string and separate out the files.
-      String removeWhitespace = files.replaceAll("\\s", "");
-      String[] arr = removeWhitespace.split(",");
-      String output = "";
+  void deleteRemoteFile(String filename) {
+    String workingDir;
+    if (filename.contains(",")) {
+      // Delete multiple files. Parse list of file names into string array and trim whitespace.
+      String [] filesToDelete = filename.replaceAll("\\s", "").split(",");
+
       try {
-        pwd = channelSftp.pwd();
-        StringBuilder sb = new StringBuilder();
-        for (String file : arr) {
+        workingDir = channelSftp.pwd();
+        for (String file : filesToDelete) {
           channelSftp.rm(file);
-          sb.append(file);
-          sb.append(" has been deleted from:");
-          sb.append(pwd);
-          sb.append("\n");
+          out.println(file + " has been deleted from: " + workingDir);
         }
-        output = sb.toString();
-        out.println("The files have been deleted from: " + pwd);
       } catch (Exception e) {
         out.println("Error deleting remote files.");
       }
-      out.println(output);
+
     } else {
       // Only one file to delete.
       try {
-        channelSftp.rm(files);
-        pwd = channelSftp.pwd();
-        out.println("The file has been deleted from: " + pwd);
+        channelSftp.rm(filename);
+        workingDir = channelSftp.pwd();
+        out.println(filename + " has been deleted from: " + workingDir);
       } catch (Exception e) {
         out.println("Error deleting remote files.");
       }

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -581,10 +581,10 @@ public class Client {
   }
 
   /**
-   * Deletes a file from the remote server. Can take one or multiple files in the format
-   * "testfile.txt, testfile2.txt"
+   * Deletes specified the file(s) from the remote server. Multiple file names can be included through a comma-separated
+   * list.
    *
-   * @param files -- The string read in main containing the names of the files.
+   * @param filename The string containing the name(s) of the file(s) to be deleted.
    */
   void deleteRemoteFile(String files) {
     String pwd;
@@ -611,6 +611,7 @@ public class Client {
       }
       out.println(output);
     } else {
+      // Only one file to delete.
       try {
         channelSftp.rm(files);
         pwd = channelSftp.pwd();


### PR DESCRIPTION
### Overview 
Completed modifications to the `deleteRemoteFile` method and initialized `logger` variable. 

Modifications to the Client class include:
* **Initialization of the `logger` data member**: I was having `NULL POINTER EXCEPTIONS` due to it not being initialized. See error below:
![Screen Shot 2020-02-23 at 10 57 17 PM](https://user-images.githubusercontent.com/38337779/75134963-cfd1c080-5694-11ea-899f-593de79ca244.png)

* **Update to the javadoc method comments**
  * New wording provides a complete yet concise description of the expected parameters and method functionality
* **Changed variable name from `file` to `filename`**
* **Changed variable name from `pwd` to `workingDir`**
* **Condensed parsing of multiple filenames to one line**
  * It seemed unnecessary to split this up into two lines. Additionally, the edit made to the comment preceding this line clarifies how the parsing is performed.
* **Replaced the use of a StringBuilder object with simple String concatenation**
  * Due to there only being one string with 3 components, the performance benefits of using a StringBuilder are outweighed by the improved legibility of String concatenation