### PR TITLE
Modify createLocalDir method in Client class

### DIFF
--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -532,28 +532,30 @@ public class Client {
   /** Wrapper to create a directory on the user's local machine. */
   void createLocalDir() {
     logger.log("createLocalDir called");
-    boolean repeat = true;
-    String dirName;
-    String answer;
+    File newDir = new File(channelSftp.lpwd() + "/" + dirName);
 
-    while (repeat) {
-      out.println("Enter the name of the new directory: ");
-      dirName = scanner.next();
-      String path = channelSftp.lpwd() + "/" + dirName;
-      File newDir = new File(path);
-      if (newDir.exists()) { // directory exists
-        out.println("A directory by this name exists. Overwrite? (yes/no)");
-        answer = scanner.next();
-        if (answer.equalsIgnoreCase("yes")) {
-          if (newDir.delete() && createLocalDir(newDir))
+    if (newDir.exists()) {
+      out.println("A directory by this name exists. Overwrite? (yes/no)");
+      if (scanner.next().equalsIgnoreCase("yes")) {
+        // Overwrite existing directory by deleting and then recreating it
+        if (newDir.delete())
+          try {
+            newDir.mkdir();
             out.println(dirName + " has been overwritten");
-          else out.println("Error overwriting file");
-          repeat = false;
-        }
-      } else {
-        if (!createLocalDir(newDir)) out.println("Error creating local directory.");
+          } catch (Exception e) {
+            out.println("Error creating directory");
+          }
+        else
+          out.println("Error overwriting directory");
+      }
+    }
+
+    else {
+      try {
+        newDir.mkdir();
         out.println(dirName + " has been created");
-        repeat = false;
+      } catch (Exception e) {
+        out.println("Error creating directory.");
       }
     }
   }

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -558,22 +558,6 @@ public class Client {
     }
   }
 
-  /**
-   * Called by createLocalDir() to make a new local directory in current local path
-   *
-   * @param newDir -- File to create in current local path
-   * @return true if file was successfully created
-   */
-  boolean createLocalDir(File newDir) {
-    boolean pass = false;
-    try {
-      pass = newDir.mkdir();
-    } catch (Exception e) {
-      out.println("Error creating directory.");
-    }
-    return pass;
-  }
-
   /** Displays log history to user and logs being invoked */
   void displayLogHistory() {
     logger.display();

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -529,8 +529,13 @@ public class Client {
     }
   }
 
-  /** Wrapper to create a directory on the user's local machine. */
-  void createLocalDir() {
+  /**
+   * Creates a directory in the user's current path. If a directory with the same name already
+   * exists, the user is prompted to determine whether or not to overwrite it.
+   *
+   * @param dirName the string containing the name of the directory to be created.
+   */
+  void createLocalDir(String dirName) {
     logger.log("createLocalDir called");
     File newDir = new File(channelSftp.lpwd() + "/" + dirName);
 

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -574,7 +574,7 @@ public class Client {
     return pass;
   }
 
-  /** Displays log history to user */
+  /** Displays log history to user and logs being invoked */
   void displayLogHistory() {
     logger.display();
     logger.log("displayLogHistory called");
@@ -587,6 +587,8 @@ public class Client {
    * @param filename the string containing the name(s) of the file(s) to be deleted.
    */
   void deleteRemoteFile(String filename) {
+    logger.log("deleteRemoteFile called");
+
     String workingDir;
     if (filename.contains(",")) {
       // Delete multiple files. Parse list of file names into string array and trim whitespace.

--- a/src/main/java/edu/pdx/cs/sftp/Main.java
+++ b/src/main/java/edu/pdx/cs/sftp/Main.java
@@ -260,6 +260,7 @@ public class Main {
    * @throws SftpException from JSCH
    */
   private static void createDirectory(Client client) throws SftpException {
+    Scanner scanner = new Scanner(System.in);
     var menu = new Menu();
     int opt;
     do {
@@ -283,7 +284,9 @@ public class Main {
           break;
         case 5:
           System.out.println("Create local directory...");
-          client.createLocalDir();
+          out.println("Enter the name of the new directory: ");
+          String dirName = scanner.nextLine();
+          client.createLocalDir(dirName);
           break;
         case 6:
           client.createRemoteDir();

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -224,9 +224,9 @@ public class ClientTest {
       assert(false);
     }
     String dirName = "newDirectory";
-    String path = client.getChannelSftp().lpwd() + "/" + dirName;
-    File newDir = new File(path);
-    assertThat(client.createLocalDir(newDir), equalTo(true));
+    File newDir = new File(client.getChannelSftp().lpwd() + "/" + dirName);
+    client.createLocalDir(dirName);
+    assertThat(newDir.exists(), equalTo(true));
     System.out.println(dirName + " was created successfully");
     if (newDir.delete())        //clean up
       System.out.println(dirName + " was deleted");


### PR DESCRIPTION
### Overview 
Completed modifications to the `createLocalDir()` method and its related unit test. 

Modifications to the Client class include:
* **Invoking the logger at the beginning of the method to match logging functionality included in other methods**
* **Update to the javadoc method comments**
  * New wording provides a complete yet concise description of the expected parameters and method functionality
* **Improved overall functionality and logic by removing unnecessary loop and exiting gracefully with helpful messages in case there was an issue overwriting or creating a directory.**
* **Moved prompt for the name of the directory to be created to `Main()` in order to match the `deleteRemoteFile()` method.**