### PR TITLE
Refactor unit tests for connect() method

### DIFF
--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -14,9 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class ClientTest {
-  /**
-   * These need to be filled in before the tests will run properly.
-   */
+  /* These need to be filled in before the tests will run properly. */
   private String username = "u";
   private String password = "p";
   private String hostname = "h";
@@ -42,81 +40,68 @@ public class ClientTest {
     assertThat(client.connect(), equalTo(false));
   }
 
-  /**
-   * Trying to upload a file should result in an error. Expects an SftpException.
-   */
+  /** Trying to upload a file should result in an error. Expects an SftpException. */
   @Test(expected = SftpException.class)
   public void uploadFakeFile_expectsSftpException() throws SftpException {
     Client client = new Client("fakeUsername", "fakePassword", "fakeHostname");
-    if(!client.connect()) {
+    if (!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
-      assert(false);
+      assert (false);
     }
 
-    //try uploading a non existent file.
+    // try uploading a non existent file.
     client.uploadFile("This is not a file");
   }
 
-  /**
-   * Should throw exception when file not found when upload attempted
-   */
+  /** Should throw exception when file not found when upload attempted */
   @Test(expected = SftpException.class)
   public void uploadFile_expectsSftpException_NoSuchFile() throws SftpException {
     String fileName = "MissingTextFile.txt";
 
     Client client = new Client(username, password, hostname);
-    if(!client.connect()) {
+    if (!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
-      assert(false);
+      assert (false);
     }
 
     client.uploadFile(fileName);
   }
 
-  /**
-   * Asserts uploaded file exists
-   */
+  /** Asserts uploaded file exists */
   @Test
   public void uploadFile_assertsFileExists() throws SftpException, IOException {
     String fileName = "testfile.txt";
     File file = new File(fileName);
-    if (file.createNewFile())
-      System.out.println("Added testfile.txt to local");
-    else
-      System.out.println("Could not add testfile.txt to local");
+    if (file.createNewFile()) System.out.println("Added testfile.txt to local");
+    else System.out.println("Could not add testfile.txt to local");
     boolean pass = false;
     SftpATTRS attrs;
 
     Client client = new Client(username, password, hostname);
-    if(!client.connect()) {
+    if (!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
-      assert(false);
+      assert (false);
     }
     client.uploadFile(fileName);
     attrs = client.getChannelSftp().stat(fileName);
-    if (attrs != null)
-      pass = true;
+    if (attrs != null) pass = true;
     System.out.println("Now deleting the files you uploaded.");
     client.deleteRemoteFile(fileName);
     assertThat(pass, equalTo(true));
-    if (file.delete())
-      System.out.println("Deleted testfile.txt from local");
-    else
-      System.out.println("Could not delete testfile.txt from local");
+    if (file.delete()) System.out.println("Deleted testfile.txt from local");
+    else System.out.println("Could not delete testfile.txt from local");
   }
 
-  /**
-   * Asserts uploaded file was deleted. stat() throws exception if filename is not found.
-   */
+  /** Asserts uploaded file was deleted. stat() throws exception if filename is not found. */
   @Test(expected = SftpException.class)
   public void deleteFile_expectsSftpException() throws SftpException {
     String fileName = "testfile.txt";
     SftpATTRS attrs = null;
 
     Client client = new Client(username, password, hostname);
-    if(!client.connect()) {
+    if (!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
-      assert(false);
+      assert (false);
     }
 
     client.uploadFile(fileName);
@@ -126,18 +111,19 @@ public class ClientTest {
   }
 
   /**
-   * Trying to upload a file that does not exist should result in an error. This test verifies that is the case.
+   * Trying to upload a file that does not exist should result in an error. This test verifies that
+   * is the case.
    */
   @Test
   public void downloadFakeFile() {
     Client client = new Client(username, password, hostname);
     try {
-      if(!client.connect()) {
+      if (!client.connect()) {
         System.out.println("Failed connection. Unable to run test.");
-        assert(false);
+        assert (false);
       }
 
-      //try downloading a non existent file.
+      // try downloading a non existent file.
       try {
         client.downloadFile("This is not a file");
       } catch (Exception e) {
@@ -151,9 +137,7 @@ public class ClientTest {
     }
   }
 
-  /**
-   * Test whether a file is uploaded correctly.
-   */
+  /** Test whether a file is uploaded correctly. */
   @Test
   public void downloadFile() {
     String fileName = "testfile.txt";
@@ -161,21 +145,21 @@ public class ClientTest {
 
     Client client = new Client(username, password, hostname);
     try {
-      if(!client.connect()) {
+      if (!client.connect()) {
         System.out.println("Failed connection. Unable to run test.");
-        assert(false);
+        assert (false);
       }
 
-      //try downloading a file
+      // try downloading a file
       try {
         client.downloadFile(fileName);
         client.downloadFile(fileName2);
-        //verify that the file is in the local directory
+        // verify that the file is in the local directory
         File dir = new File(client.getChannelSftp().lpwd());
         File[] files = dir.listFiles();
         for (File file : files) {
           if (file.getName().equals(fileName)) {
-            //the file was found so the download was successful.
+            // the file was found so the download was successful.
             assertThat(file.getName(), equalTo(fileName));
           }
         }
@@ -190,46 +174,39 @@ public class ClientTest {
     }
   }
 
-  /**
-   * Asserts whether a remote directory is created
-   */
+  /** Asserts whether a remote directory is created */
   @Test
   public void createRemoteDir_assertsDirExists() throws SftpException {
     Client client = new Client(username, password, hostname);
-    if(!client.connect()) {
+    if (!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
-      assert(false);
+      assert (false);
     }
 
     String dirName = "newDirectory";
     assertThat(client.createRemoteDir(dirName), equalTo(true));
     System.out.println(dirName + " was created successfully");
-    client.getChannelSftp().rmdir(dirName);        //clean up
+    client.getChannelSftp().rmdir(dirName); // clean up
   }
 
-  /**
-   * Asserts whether a local directory is created
-   */
+  /** Asserts whether a local directory is created */
   @Test
   public void createLocalDir_assertsDirExists() {
     Client client = new Client(username, password, hostname);
-    if(!client.connect()) {
+    if (!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
-      assert(false);
+      assert (false);
     }
     String dirName = "newDirectory";
     String path = client.getChannelSftp().lpwd() + "/" + dirName;
     File newDir = new File(path);
     assertThat(client.createLocalDir(newDir), equalTo(true));
     System.out.println(dirName + " was created successfully");
-    if (newDir.delete())        //clean up
-      System.out.println(dirName + " was deleted");
+    if (newDir.delete()) // clean up
+    System.out.println(dirName + " was deleted");
   }
 
-  /**
-   * Asserts whether a local directory was changed
-   * Also inherently tests printLocalWorkingDir()
-   */
+  /** Asserts whether a local directory was changed Also inherently tests printLocalWorkingDir() */
   @Test
   public void changeLocalDir_assertsDirChanged() {
     boolean pass = false;
@@ -239,26 +216,28 @@ public class ClientTest {
     File newDir = new File(newLocalPath);
 
     Client client = new Client(username, password, hostname);
-    if(!client.connect()) {
+    if (!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
-      assert(false);
+      assert (false);
     }
 
-    if(newDir.mkdir()) {          //create new directory path
+    if (newDir.mkdir()) { // create new directory path
       System.setOut(new PrintStream(output));
       output.reset();
       client.printLocalWorkingDir();
-      assertThat(output.toString().contains(newLocalPath), equalTo(false)); //assert current path is not newDir
-      client.changeLocalWorkingDir(newLocalPath);       //change path to newDir
+      assertThat(
+          output.toString().contains(newLocalPath),
+          equalTo(false)); // assert current path is not newDir
+      client.changeLocalWorkingDir(newLocalPath); // change path to newDir
       output.reset();
       client.printLocalWorkingDir();
-      assertThat(output.toString(), containsString(newLocalPath));    //assert current path is newDir
-      client.changeLocalWorkingDir("..");       //reset path
-      System.setOut(stdout);    //reset output to standard System.out
-      if(!newDir.delete())
-        System.out.println("Error deleting testing directory");
+      assertThat(output.toString(), containsString(newLocalPath)); // assert current path is newDir
+      client.changeLocalWorkingDir(".."); // reset path
+      System.setOut(stdout); // reset output to standard System.out
+      if (!newDir.delete()) System.out.println("Error deleting testing directory");
       else {
-        System.out.println("Path successfully changed to new dir. New dir has been deleted and path is reset.");
+        System.out.println(
+            "Path successfully changed to new dir. New dir has been deleted and path is reset.");
         pass = true;
       }
     } else {
@@ -269,8 +248,7 @@ public class ClientTest {
   }
 
   /**
-   * Asserts whether a remote directory was changed
-   * Also inherently tests printRemoteWorkingDir()
+   * Asserts whether a remote directory was changed Also inherently tests printRemoteWorkingDir()
    */
   @Test
   public void changeRemoteDir_assertsDirChanged() throws SftpException {
@@ -280,25 +258,28 @@ public class ClientTest {
     String newRemotePath = "newRemotePath";
 
     Client client = new Client(username, password, hostname);
-    if(!client.connect()) {
+    if (!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
-      assert(false);
+      assert (false);
     }
 
     if (client.createRemoteDir(newRemotePath)) {
       System.setOut(new PrintStream(output));
       output.reset();
       client.printRemoteWorkingDir();
-      assertThat(output.toString().contains(newRemotePath), equalTo(false)); //assert current path is not newDir
-      client.changeRemoteWorkingDir(newRemotePath);       //change path to newDir
+      assertThat(
+          output.toString().contains(newRemotePath),
+          equalTo(false)); // assert current path is not newDir
+      client.changeRemoteWorkingDir(newRemotePath); // change path to newDir
       output.reset();
       client.printRemoteWorkingDir();
-      assertThat(output.toString(), containsString(newRemotePath));    //assert current path is newDir
-      client.changeRemoteWorkingDir("..");       //reset path
-      System.setOut(stdout);    //reset output to standard System.out
+      assertThat(output.toString(), containsString(newRemotePath)); // assert current path is newDir
+      client.changeRemoteWorkingDir(".."); // reset path
+      System.setOut(stdout); // reset output to standard System.out
 
       client.getChannelSftp().rmdir(newRemotePath);
-      System.out.println("Path successfully changed to new dir. New dir has been deleted and path is reset.");
+      System.out.println(
+          "Path successfully changed to new dir. New dir has been deleted and path is reset.");
       pass = true;
     } else {
       System.setOut(stdout);
@@ -308,8 +289,7 @@ public class ClientTest {
   }
 
   /**
-   * Asserts whether a remote directory was changed
-   * Also inherently tests printRemoteWorkingDir()
+   * Asserts whether a remote directory was changed Also inherently tests printRemoteWorkingDir()
    */
   @Test
   public void disconnect_assertsSessionIsDisconnected() {
@@ -326,9 +306,7 @@ public class ClientTest {
     assertThat(pass, equalTo(true));
   }
 
-  /**
-   * Asserts whether a directory's files are displayed
-   */
+  /** Asserts whether a directory's files are displayed */
   @Test
   public void displayRemoteFiles_assertsFilesAndDirectoriesDisplay() throws SftpException {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -339,19 +317,18 @@ public class ClientTest {
     Client client = new Client(username, password, hostname);
     if (!client.connect()) {
       System.out.println("Failed connection. Unable to run test.");
-      assert(false);
+      assert (false);
     }
 
     if (client.createRemoteDir(dirName)) {
-      System.setOut(new PrintStream(output));   //Redirect printstream
+      System.setOut(new PrintStream(output)); // Redirect printstream
       client.displayRemoteFiles();
-      assertThat(output.toString(), containsString(dirName));   //Assert output contains new dir
-      client.getChannelSftp().rmdir(dirName);        //clean up
-      System.setOut(stdout);      //Reset printstream to System.out
+      assertThat(output.toString(), containsString(dirName)); // Assert output contains new dir
+      client.getChannelSftp().rmdir(dirName); // clean up
+      System.setOut(stdout); // Reset printstream to System.out
       System.out.println("New remote file successfully displayed. New dir has been deleted.");
       pass = true;
-    } else
-      System.out.println("Error in createRemoteDir");
+    } else System.out.println("Error in createRemoteDir");
 
     assertThat(pass, equalTo(true));
   }

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -30,21 +30,15 @@ public class ClientTest {
     // assertThat(expected, equalTo(actual));
   }
 
-  /**
-   * Asserts that the connect method returns true
-   */
   @Test
-  public void connection_assertsSuccessfulConnection() {
+  public void connect_SuccessfulConnection_ReturnsTrue() {
     Client client = new Client(username, password, hostname);
     assertThat(client.connect(), equalTo(true));
   }
 
-  /**
-   * Test connection with fake credentials. Asserts connect() returns false.
-   */
   @Test
-  public void connection_wrongCredentials_expectsSftpException() {
-    Client client = new Client("fakeUsername", "fakePassword", "fakeHostname");
+  public void connect_InvalidCredentials_ReturnsFalse() {
+    Client client = new Client("invalidUsername", "invalidPassword", "invalidHostname");
     assertThat(client.connect(), equalTo(false));
   }
 


### PR DESCRIPTION
### Overview
Updated my analysis to include my observations of the unit tests, and made a couple minor changes to the unit tests for the `connect()` method:

**Renamed unit tests**: Following [Naming standards for unit tests](https://osherove.com/blog/2005/4/3/naming-standards-for-unit-tests.html) by Roy Osherove, I renamed the unit tests for the `connect()` method to follow this schema: **`methodName_StateUnderTest_ExpectedBehavior`**

**Removed javadoc**: As stated in my analysis, the doc comments included for the unit tests state the obvious and do not provide any new information (considered a "noise" comment in _Clean Code_). I personally feel that unit tests should be self-documenting with descriptive names so they can be easily understood from a quick scan. 

**Formatting**: Reformatted the file to adhere to the Google Java Style Guide.
