### PR TITLE
Disconnect() unit test/method modifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,5 +44,11 @@
         <version>1.9.5</version>
         <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>4.0.2</version>
+        <scope>test</scope>
+    </dependency>
 </dependencies>
 </project>

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -129,12 +129,19 @@ public class Client {
     return true;
   }
 
-  /** Terminates connection */
+  /**
+   * Terminates the connection to the SSH/SFTP server by first exiting the SFTP channel, then
+   * closing the session maintaining the connection to the server.
+   */
   void disconnect() {
     channelSftp.exit();
     session.disconnect();
+
     logger.log("SFTP connection closed");
     logger.save(user.username + "@" + user.hostname);
+
+    out.println("SFTP connection closed");
+    out.println("A log file has been saved to your local Downloads directory");
   }
 
   /**
@@ -550,12 +557,9 @@ public class Client {
           } catch (Exception e) {
             out.println("Error creating directory");
           }
-        else
-          out.println("Error overwriting directory");
+        else out.println("Error overwriting directory");
       }
-    }
-
-    else {
+    } else {
       try {
         newDir.mkdir();
         out.println(dirName + " has been created");
@@ -572,8 +576,8 @@ public class Client {
   }
 
   /**
-   * Deletes the specified file(s) from the remote server. Multiple file names can be included through a comma-separated
-   * list.
+   * Deletes the specified file(s) from the remote server. Multiple file names can be included
+   * through a comma-separated list.
    *
    * @param filename the string containing the name(s) of the file(s) to be deleted.
    */
@@ -583,7 +587,7 @@ public class Client {
     String workingDir;
     if (filename.contains(",")) {
       // Delete multiple files. Parse list of file names into string array and trim whitespace.
-      String [] filesToDelete = filename.replaceAll("\\s", "").split(",");
+      String[] filesToDelete = filename.replaceAll("\\s", "").split(",");
 
       try {
         workingDir = channelSftp.pwd();

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -288,22 +288,19 @@ public class ClientTest {
     assertThat(pass, equalTo(true));
   }
 
-  /**
-   * Asserts whether a remote directory was changed Also inherently tests printRemoteWorkingDir()
-   */
   @Test
-  public void disconnect_assertsSessionIsDisconnected() {
-    boolean pass = false;
+  public void disconnect_SuccessfullyDisconnectSession_ReturnsTrue() throws InterruptedException {
     Client client = new Client(username, password, hostname);
-    if (client.connect()) {
-      System.out.println("Now disconnecting your session...");
-      client.disconnect();
-      assertThat(client.getSession().isConnected(), equalTo(false));
-      pass = true;
-    } else {
-      System.out.println("Connection error.");
-    }
-    assertThat(pass, equalTo(true));
+    await()
+        .until(
+            () -> {
+              return client.connect();
+            });
+    assertThat(client.getSession().isConnected(), equalTo(true));
+
+    client.disconnect();
+
+    assertThat(client.getSession().isConnected(), equalTo(false));
   }
 
   /** Asserts whether a directory's files are displayed */

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -290,7 +290,7 @@ public class ClientTest {
   }
 
   @Test
-  public void disconnect_SuccessfullyDisconnectSession_ReturnsTrue() throws InterruptedException {
+  public void disconnect_SuccessfulDisconnect_VerifiesConnectionClosed() {
     Client client = new Client(username, password, hostname);
     await()
         .until(


### PR DESCRIPTION
### Overview 
You can view my critical analysis of the `disconnect()` method in our Critical Analysis document; overall, I found the method to be clear and readable. Below is a short list of modifications I felt improved the code's readability a bit: 

**Unit Test**
* Rename unit test to follow [MethodName_StateUnderTest_ExpectedBehavior] naming scheme:
 ❌ `disconnect_assertSessionIsDisconnected`
 ✅ `disconnect_SuccessfulDisconnect_VerifiesConnectionClosed`
* Refactor test 
  * Use "Arrange, Act, Assert" testing pattern/format 
  * Remove output to user
  * Remove conditional statements in test (if-else) 
  * Add [Awaitility](https://github.com/awaitility/awaitility) to ensure connection is established before attempting to disconnect
  * Remove redundant assertions; rather than asserting (twice) that the disconnect occurred, we assert: 
    * A connection was established
    * A connection was terminated

**Method**
* Expand Javadoc to be more descriptive 
* Add output to the user to signify the disconnect occurred
* Use vertical space to separate the method into three logical subsections 