### PR TITLE
Modify documentation for getters

### DIFF
--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -145,18 +145,14 @@ public class Client {
   }
 
   /**
-   * Simple getter for cSftp for use in test suite.
-   *
-   * @return -- returns the cSftp object.
+   * @return returns a Channel object connected to an SFTP server.
    */
   ChannelSftp getChannelSftp() {
     return channelSftp;
   }
 
   /**
-   * Simple getter for session for use in test suite.
-   *
-   * @return -- returns the Session object.
+   * @return returns a Session object representing a connection to an SSH server.
    */
   Session getSession() {
     return session;

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -144,12 +144,12 @@ public class Client {
     out.println("A log file has been saved to your local Downloads directory");
   }
 
-  /** @return returns a Channel object connected to an SFTP server. */
+  /** @return a Channel object connected to an SFTP server. */
   ChannelSftp getChannelSftp() {
     return channelSftp;
   }
 
-  /** @return returns a Session object representing a connection to an SSH server. */
+  /** @return a Session object representing a connection to an SSH server. */
   Session getSession() {
     return session;
   }

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -144,16 +144,12 @@ public class Client {
     out.println("A log file has been saved to your local Downloads directory");
   }
 
-  /**
-   * @return returns a Channel object connected to an SFTP server.
-   */
+  /** @return returns a Channel object connected to an SFTP server. */
   ChannelSftp getChannelSftp() {
     return channelSftp;
   }
 
-  /**
-   * @return returns a Session object representing a connection to an SSH server.
-   */
+  /** @return returns a Session object representing a connection to an SSH server. */
   Session getSession() {
     return session;
   }


### PR DESCRIPTION
### Overview
Getter methods are exactly what you'd expect; for this PR, I focused on the documentation for the getters, making the following improvements:

* Removed extra comments in the Javadoc explaining what the getters return (this should be evident by the method itself)
  * To generate clean, complete Javadoc, I kept the `@return` tag, and updated the description to be a little more detailed

The Javadoc for the getters looks like this: 
<img width="894" alt="Screen Shot 2020-03-02 at 2 31 18 PM" src="https://user-images.githubusercontent.com/23347186/75724399-26da2580-5c93-11ea-8377-8aa1ac378d91.png">