### PR TITLE
Modify methods for displaying local/remote files

### DIFF
--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -9,11 +9,10 @@ import com.jcraft.jsch.SftpATTRS;
 import com.jcraft.jsch.SftpException;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.Properties;
-import java.util.Scanner;
-import java.util.Vector;
+import java.lang.reflect.Array;
+import java.util.*;
 
+import static java.lang.System.err;
 import static java.lang.System.out;
 
 /**
@@ -190,7 +189,13 @@ public class Client {
     }
   }
 
-  /** Lists all directories and files on the user's remote machine. */
+  /**
+   * Lists all directories and files in the user's current remote directory.
+   *
+   * @return <code>true</code> if directories and/or files in the user's current remote directory
+   *     are listed; otherwise, return <code>false</code> to indicate the user's current remote
+   *     directory is empty.
+   */
   boolean displayRemoteFiles() {
     logger.log("displayRemoteFiles called");
 
@@ -198,24 +203,20 @@ public class Client {
       printRemoteWorkingDir();
       Vector remoteDir = channelSftp.ls(channelSftp.pwd());
       if (remoteDir != null) {
-        int count = 0;
         for (int i = 0; i < remoteDir.size(); ++i) {
-          if (count == 5) {
-            count = 0;
-            out.println();
-          }
           Object dirEntry = remoteDir.elementAt(i);
           if (dirEntry instanceof ChannelSftp.LsEntry)
-            out.print(((ChannelSftp.LsEntry) dirEntry).getFilename() + "    ");
-          ++count;
+            out.println(((ChannelSftp.LsEntry) dirEntry).getFilename());
         }
-        out.println("\n");
+        out.println();
+        return true;
+      } else {
+        out.println("Your current directory is empty.");
       }
-      return true;
     } catch (SftpException e) {
-      System.out.println("Error displaying remote files");
-      return false;
+      err.println("Error displaying remote files");
     }
+    return false;
   }
 
   /** Create a directory on the user's remote machine. */

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -9,8 +9,10 @@ import com.jcraft.jsch.SftpATTRS;
 import com.jcraft.jsch.SftpException;
 
 import java.io.File;
-import java.lang.reflect.Array;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.Scanner;
+import java.util.Vector;
 
 import static java.lang.System.err;
 import static java.lang.System.out;

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -9,6 +9,7 @@ import com.jcraft.jsch.SftpATTRS;
 import com.jcraft.jsch.SftpException;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.Scanner;
 import java.util.Vector;
@@ -162,25 +163,31 @@ public class Client {
     return session;
   }
 
-  /** Lists all directories and files on the user's local machine (from the current directory). */
-  int displayLocalFiles() {
+  /**
+   * Lists all directories and files in the user's current local directory.
+   *
+   * @return <code>true</code> if directories and/or files in the user's current local directory are
+   *     listed; otherwise, return <code>false</code> to indicate the user's current local directory
+   *     is empty.
+   */
+  boolean displayLocalFiles() {
     logger.log("displayLocalFiles called");
-    File dir = new File(channelSftp.lpwd());
     printLocalWorkingDir();
+
+    File dir = new File(channelSftp.lpwd());
     File[] files = dir.listFiles();
+
     if (files != null) {
-      int count = 0;
+      Arrays.sort(files);
       for (File file : files) {
-        if (count == 5) {
-          count = 0;
-          out.println();
-        }
-        out.print(file.getName() + "    ");
-        ++count;
+        out.println(file.getName());
       }
-      out.println("\n");
+      out.println();
+      return true;
+    } else {
+      out.println("Your current directory is empty.");
+      return false;
     }
-    return 1;
   }
 
   /** Lists all directories and files on the user's remote machine. */

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -292,11 +292,7 @@ public class ClientTest {
   @Test
   public void disconnect_SuccessfulDisconnect_VerifiesConnectionClosed() {
     Client client = new Client(username, password, hostname);
-    await()
-        .until(
-            () -> {
-              return client.connect();
-            });
+    await().until(() -> client.connect());
     assertThat(client.getSession().isConnected(), equalTo(true));
 
     client.disconnect();

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -304,30 +304,22 @@ public class ClientTest {
     assertThat(client.getSession().isConnected(), equalTo(false));
   }
 
-  /** Asserts whether a directory's files are displayed */
   @Test
-  public void displayRemoteFiles_assertsFilesAndDirectoriesDisplay() throws SftpException {
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    PrintStream stdout = System.out;
-    String dirName = "newDirectory";
-    boolean pass = false;
-
+  public void displayRemoteFiles_Success_VerifiesDirectoryDisplayed() throws SftpException {
+    // Redirect output stream
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(byteArrayOutputStream));
+    // Connect to SSH/SFTP server
     Client client = new Client(username, password, hostname);
-    if (!client.connect()) {
-      System.out.println("Failed connection. Unable to run test.");
-      assert (false);
-    }
+    await().until(() -> client.connect());
+    // Create new directory to verify
+    client.createRemoteDir("dirToTest");
 
-    if (client.createRemoteDir(dirName)) {
-      System.setOut(new PrintStream(output)); // Redirect printstream
-      client.displayRemoteFiles();
-      assertThat(output.toString(), containsString(dirName)); // Assert output contains new dir
-      client.getChannelSftp().rmdir(dirName); // clean up
-      System.setOut(stdout); // Reset printstream to System.out
-      System.out.println("New remote file successfully displayed. New dir has been deleted.");
-      pass = true;
-    } else System.out.println("Error in createRemoteDir");
+    client.displayRemoteFiles();
 
-    assertThat(pass, equalTo(true));
+    assertThat(byteArrayOutputStream.toString(), containsString("dirToTest"));
+    // Clean up
+    client.getChannelSftp().rmdir("dirToTest");
+    System.setOut(System.out);
   }
 }


### PR DESCRIPTION
### Overview
The following modifications were made to improve code readability, create more comprehensive documentation, and provide a better user experience. 

For the `displayLocalFiles()` method:
* Returns a boolean value
  * True indicates directories and/or files in the user’s current local directory were listed, while false indicates the user’s current local directory was empty. For this application, the next logical step after this method is called is typically to upload a document to the remote server; the boolean value will be more useful to catch in order to determine the next step or message to the user. For example, if no files are found in the user’s current local directory, we should not prompt the user for a file name to upload. 
* Uses vertical space to break the method into logical subsections.
* If directories and/or files are found, they are sorted alphabetically. 
* Each file name is printed on a single line, removing the need for a counter and odd print statements. 
* If the user’s current local directory is empty, a message is printed to the user on the terminal to indicate as such. 

For the `displayRemoteFiles()` method:
* Each file name is printed on a single line, removing the need for a counter and odd print statements. 
* If the user’s current local directory is empty, a message is printed to the user on the terminal to indicate as such. 
* Refactor corresponding unit test to follow "Arrange, Act, Assert" pattern. 
  * On another iteration (or future work), should extract the clean up that occurs within the unit test. (Not sure exactly how to do this.) 