### PR TITLE
Modify print methods

### DIFF
--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -270,7 +270,7 @@ public class Client {
   void printLocalWorkingDir() {
     logger.log("printLocalWorkingDir called");
     String localWorkingDir = channelSftp.lpwd();
-    out.println(String.format("This is your current local working directory: %s \n", localWorkingDir);
+    out.println(String.format("This is your current local working directory: %s \n", localWorkingDir));
   }
 
   /**
@@ -281,7 +281,7 @@ public class Client {
   void printRemoteWorkingDir() throws SftpException {
     logger.log("printRemoteWorkingDir called");
     String remoteWorkingDir = channelSftp.pwd();
-    out.println(String.format("This is your current remote working directory: %s \n", remoteWorkingDir);
+    out.println(String.format("This is your current remote working directory: %s \n", remoteWorkingDir));
   }
 
   /** Wrapper for changing current working local path */

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -264,18 +264,24 @@ public class Client {
     return attrs != null;
   }
 
-  /** Print current working local path */
+  /**
+   * Prints the current local directory in absolute form.
+   */
   void printLocalWorkingDir() {
     logger.log("printLocalWorkingDir called");
-    String lpwd = channelSftp.lpwd();
-    out.println("This is your current local working directory: " + lpwd + "\n");
+    String localWorkingDir = channelSftp.lpwd();
+    out.println(String.format("This is your current local working directory: %s \n", localWorkingDir);
   }
 
-  /** Print current working remote path */
+  /**
+   * Prints the current remote directory in absolute form.
+   *
+   * @throws SftpException
+   */
   void printRemoteWorkingDir() throws SftpException {
     logger.log("printRemoteWorkingDir called");
-    String pwd = channelSftp.pwd();
-    out.println("This is your current remote working directory: " + pwd + "\n");
+    String remoteWorkingDir = channelSftp.pwd();
+    out.println(String.format("This is your current remote working directory: %s \n", remoteWorkingDir);
   }
 
   /** Wrapper for changing current working local path */

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -264,24 +264,24 @@ public class Client {
     return attrs != null;
   }
 
-  /**
-   * Prints the current local directory in absolute form.
-   */
+  /** Prints the current local directory in absolute form. */
   void printLocalWorkingDir() {
     logger.log("printLocalWorkingDir called");
     String localWorkingDir = channelSftp.lpwd();
-    out.println(String.format("This is your current local working directory: %s \n", localWorkingDir));
+    out.println(
+        String.format("This is your current local working directory: %s \n", localWorkingDir));
   }
 
   /**
    * Prints the current remote directory in absolute form.
    *
-   * @throws SftpException
+   * @throws SftpException If an SFTP protocol exception occurred
    */
   void printRemoteWorkingDir() throws SftpException {
     logger.log("printRemoteWorkingDir called");
     String remoteWorkingDir = channelSftp.pwd();
-    out.println(String.format("This is your current remote working directory: %s \n", remoteWorkingDir));
+    out.println(
+        String.format("This is your current remote working directory: %s \n", remoteWorkingDir));
   }
 
   /** Wrapper for changing current working local path */


### PR DESCRIPTION
### Overview 
* Rename variables to improve clarity:
`lpwd` ➡️ `localWorkingDirectory`
`pwd` ➡️ `remoteWorkingDirectory`
* Use String.format() to print to terminal (I think this is more readable than the String concatenation) 
* Reformat file to adhere to Google Java Style Guide