### PR TITLE
Modify change local directory method

### DIFF
--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -278,35 +278,26 @@ public class Client {
     out.println("This is your current remote working directory: " + pwd + "\n");
   }
 
-  /** Wrapper for changing current working local path */
-  void changeLocalWorkingDir() {
-    logger.log("changeLocalWorkingDir called");
-    String newDir;
-    String lpwd = channelSftp.lpwd();
-    out.println("This is your current local working directory: " + lpwd + "\n");
-    out.println("Enter the path of the directory you'd like to change to: ");
-    newDir = scanner.next();
-    if (changeLocalWorkingDir(newDir)) {
-      lpwd = channelSftp.lpwd();
-      out.println("This is your new current local working directory: " + lpwd + "\n");
-    }
-  }
-
   /**
-   * Called by changeLocalWorkingDir() to change current working local path
+   * Changes the current local directory to the new directory specified by the user.
    *
-   * @param newDir -- String of the new path name
-   * @return true if successful
+   * @return <code>true</code> if the local directory is changed successfully; <code>false</code>
+   *     otherwise.
    */
-  boolean changeLocalWorkingDir(String newDir) {
-    boolean pass = false;
+  boolean changeLocalWorkingDir() {
+    logger.log("changeLocalWorkingDir called");
+    String changeDirTo;
+    printLocalWorkingDir();
+    out.println("Enter the path of the directory you'd like to change to: ");
+    changeDirTo = scanner.next();
     try {
-      channelSftp.lcd(newDir);
-      pass = true;
+      channelSftp.lcd(changeDirTo);
+      printLocalWorkingDir();
+      return true;
     } catch (SftpException e) {
-      out.println("Error changing your directory");
+      err.println("Error changing the local directory");
     }
-    return pass;
+    return false;
   }
 
   /** Change current working remote path */

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -207,47 +207,6 @@ public class ClientTest {
     System.out.println(dirName + " was deleted");
   }
 
-  /** Asserts whether a local directory was changed Also inherently tests printLocalWorkingDir() */
-  @Test
-  public void changeLocalDir_assertsDirChanged() {
-    boolean pass = false;
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    PrintStream stdout = System.out;
-    String newLocalPath = "newLocalPath";
-    File newDir = new File(newLocalPath);
-
-    Client client = new Client(username, password, hostname);
-    if (!client.connect()) {
-      System.out.println("Failed connection. Unable to run test.");
-      assert (false);
-    }
-
-    if (newDir.mkdir()) { // create new directory path
-      System.setOut(new PrintStream(output));
-      output.reset();
-      client.printLocalWorkingDir();
-      assertThat(
-          output.toString().contains(newLocalPath),
-          equalTo(false)); // assert current path is not newDir
-      client.changeLocalWorkingDir(newLocalPath); // change path to newDir
-      output.reset();
-      client.printLocalWorkingDir();
-      assertThat(output.toString(), containsString(newLocalPath)); // assert current path is newDir
-      client.changeLocalWorkingDir(".."); // reset path
-      System.setOut(stdout); // reset output to standard System.out
-      if (!newDir.delete()) System.out.println("Error deleting testing directory");
-      else {
-        System.out.println(
-            "Path successfully changed to new dir. New dir has been deleted and path is reset.");
-        pass = true;
-      }
-    } else {
-      System.setOut(stdout);
-      System.out.println("Error in mkdir");
-    }
-    assertThat(pass, equalTo(true));
-  }
-
   /**
    * Asserts whether a remote directory was changed Also inherently tests printRemoteWorkingDir()
    */


### PR DESCRIPTION
### Overview
**Method** 
* Removed wrapper function (not entirely sure why this exists; possibly for testing purposes?) 
* Combined two methods into one to simplify logic 
* Replaced code that prints the local working directory with the utility method that prints the local directory (in two places) 
* Changed variable name from `newDir` to `changeDirTo` since it represents the directory the user intends to change into 

**Unit Test**
* Removed unit test for the following reasons:
  * It tested multiple things when it should only be testing the smallest logical unit of work
  * It was super long and difficult to understand
  * It broke when I eliminated the method that takes in a parameter (which was called by the "wrapper" function) 
    * I'm not worried about this since it would have only been testing the library's function