### PR TITLE
Rename remote method

### DIFF
--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -17,6 +17,7 @@ import static java.lang.System.err;
  * authentication functionality of SSH.
  */
 public class Client {
+  private static final int TIMEOUT = 60_000; // Set default timeout to 60 seconds to accommodate slow servers
   private Scanner scanner = new Scanner(System.in);
   private static final int TIMEOUT =
       60_000; // Set default timeout to 60 seconds to accommodate slow servers
@@ -280,12 +281,14 @@ public class Client {
     return attrs != null;
   }
 
-  /** Prints the current local directory in absolute form. */
+  /**
+   * Prints the current local directory in absolute form.
+   */
   void printLocalWorkingDir() {
     logger.log("printLocalWorkingDir called");
     String localWorkingDir = channelSftp.lpwd();
     out.println(
-        String.format("This is your current local working directory: %s \n", localWorkingDir));
+      String.format("This is your current local working directory: %s \n", localWorkingDir));
   }
 
   /**
@@ -297,14 +300,14 @@ public class Client {
     logger.log("printRemoteWorkingDir called");
     String remoteWorkingDir = channelSftp.pwd();
     out.println(
-        String.format("This is your current remote working directory: %s \n", remoteWorkingDir));
+      String.format("This is your current remote working directory: %s \n", remoteWorkingDir));
   }
 
   /**
    * Changes the current local directory to the new directory specified by the user.
    *
    * @return <code>true</code> if the local directory is changed successfully; <code>false</code>
-   *     otherwise.
+   * otherwise.
    */
   boolean changeLocalWorkingDir() {
     logger.log("changeLocalWorkingDir called");

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -465,9 +465,9 @@ public class Client {
    * Rename file/directory on remote server
    */
   void renameRemote() throws SftpException {
-    boolean repeat = true;
     String input;
     SftpATTRS attrs = null;
+
     // get original file name
     String oldFilename = "";
     while (oldFilename.equals("")) {
@@ -495,7 +495,6 @@ public class Client {
     if (attrs != null) {
       out.println("A file or directory by this name already exists. Overwrite? (yes/no)");
       input = scanner.next();
-      attrs = null;
       if (input.equalsIgnoreCase("yes") || (input.equalsIgnoreCase("y"))) rename = true;
     } else {
       rename = true;

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -465,9 +465,14 @@ public class Client {
   }
 
   /**
-   * Rename file/directory on remote server
+   * Renames the specified file on the remote server to the provided new name. If a file by the
+   * same new name exists, the user is prompted to determine whether or not to overwrite it.
+   *
+   * @param oldFilename the name of the file to be renamed.
+   * @param newFilename the new name of the file to be renamed.
+   * @throws SftpException If an SFTP protocol exception occurred
    */
-  void renameRemoteFile(String filename) throws SftpException {
+  void renameRemoteFile(String oldFilename, String newFilename) throws SftpException {
     logger.log("renameRemoteFile called");
 
     String oldFilePath = channelSftp.pwd() + "/" + oldFilename;

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -473,7 +473,7 @@ public class Client {
   /**
    * Rename file/directory on remote server
    */
-  void renameRemote() throws SftpException {
+  void renameRemoteFile(String filename) throws SftpException {
     String input;
     SftpATTRS attrs = null;
 

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -495,7 +495,7 @@ public class Client {
     if (attrs != null) {
       out.println("A file or directory by this name already exists. Overwrite? (yes/no)");
       input = scanner.next();
-      if (input.equalsIgnoreCase("yes") || (input.equalsIgnoreCase("y"))) rename = true;
+      if (input.equalsIgnoreCase("yes")) rename = true;
     } else {
       rename = true;
     }

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -522,23 +522,17 @@ public class Client {
     if (newDir.exists()) {
       out.println("A directory by this name exists. Overwrite? (yes/no)");
       if (scanner.next().equalsIgnoreCase("yes")) {
-        // Overwrite existing directory by deleting and then recreating it
-        if (newDir.delete())
-          try {
-            newDir.mkdir();
-            out.println(dirName + " has been overwritten");
-          } catch (Exception e) {
-            out.println("Error creating directory");
-          }
-        else out.println("Error overwriting directory");
-      }
+        if (newDir.delete() && newDir.mkdir())
+          out.println(dirName + " has been overwritten.");
+        else
+          out.println("Error overwriting directory.");
+      } else
+        out.println("The directory will not be overwritten.");
     } else {
-      try {
-        newDir.mkdir();
-        out.println(dirName + " has been created");
-      } catch (Exception e) {
+      if (newDir.mkdir())
+        out.println(dirName + " has been created.");
+      else
         out.println("Error creating directory.");
-      }
     }
   }
 
@@ -551,7 +545,7 @@ public class Client {
   }
 
   /**
-   * Deletes the specified file(s) from the remote server. Multiple file names can be included
+   * Deletes the specified file(s) from the remote server. Multiple filenames can be included
    * through a comma-separated list.
    *
    * @param filename the string containing the name(s) of the file(s) to be deleted.
@@ -561,7 +555,7 @@ public class Client {
 
     String workingDir;
     if (filename.contains(",")) {
-      // Delete multiple files. Parse list of file names into string array and trim whitespace.
+      // Delete multiple files. Parse list of filenames into string array and trim whitespace.
       String[] filesToDelete = filename.replaceAll("\\s", "").split(",");
 
       try {

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -474,6 +474,8 @@ public class Client {
    * Rename file/directory on remote server
    */
   void renameRemoteFile(String filename) throws SftpException {
+    logger.log("renameRemoteFile called");
+
     String input;
     SftpATTRS attrs = null;
 

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -1,12 +1,6 @@
 package edu.pdx.cs.sftp;
 
-import com.jcraft.jsch.Channel;
-import com.jcraft.jsch.ChannelSftp;
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.Session;
-import com.jcraft.jsch.SftpATTRS;
-import com.jcraft.jsch.SftpException;
+import com.jcraft.jsch.*;
 
 import java.io.File;
 import java.util.Arrays;

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -447,46 +447,6 @@ public class Client {
     }
   }
 
-  /*
-  /**
-   * Executes a command on the remote server.
-   *
-   * @param command -- The text command that you'd like to execute. (Ex: "ls -a" or "cd mydirectory")
-   */
-  /*
-  void remoteExec(String command) {
-    logger.log("remoteExec called w/ argument '" + command + "'");
-    try {
-      Channel channel = session.openChannel("Exec");
-      ((ChannelExec) channel).setCommand(command);
-      channel.setInputStream(null);
-      ((ChannelExec) channel).setErrStream(System.err);
-
-
-      channel.connect();
-      InputStream input = channel.getInputStream();
-      try {
-        InputStreamReader inputReader = new InputStreamReader(input);
-        BufferedReader bufferedReader = new BufferedReader(inputReader);
-        String line;
-
-        while ((line = bufferedReader.readLine()) != null) {
-          System.out.println(line);
-        }
-        bufferedReader.close();
-        inputReader.close();
-      } catch (IOException ex) {
-        ex.printStackTrace();
-      }
-
-      channel.disconnect();
-      session.disconnect();
-    } catch (Exception ex) {
-      ex.printStackTrace();
-    }
-  }
-  */
-
   /** Rename file/directory on remote server */
   void renameRemote() throws SftpException {
     boolean repeat = true;

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -1,12 +1,6 @@
 package edu.pdx.cs.sftp;
 
-import com.jcraft.jsch.Channel;
-import com.jcraft.jsch.ChannelSftp;
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.Session;
-import com.jcraft.jsch.SftpATTRS;
-import com.jcraft.jsch.SftpException;
+import com.jcraft.jsch.*;
 
 import java.io.File;
 import java.util.Arrays;
@@ -22,16 +16,18 @@ import static java.lang.System.out;
  * authentication functionality of SSH.
  */
 public class Client {
-  private Scanner scanner = new Scanner(System.in);
   private static final int TIMEOUT =
-      60_000; // Set default timeout to 60 seconds to accommodate slow servers
+    60_000; // Set default timeout to 60 seconds to accommodate slow servers
+  private Scanner scanner = new Scanner(System.in);
   private User user;
   private JSch jsch;
   private Session session;
   private ChannelSftp channelSftp;
   private Logger logger;
 
-  /** Class constructor. */
+  /**
+   * Class constructor.
+   */
   public Client() {
     user = new User();
     jsch = new JSch();
@@ -56,7 +52,9 @@ public class Client {
     logger = new Logger();
   }
 
-  /** Prompts the user to enter connection information such as username, password, and hostname. */
+  /**
+   * Prompts the user to enter connection information such as username, password, and hostname.
+   */
   void promptConnectionInfo() {
     user.getUsername();
     user.getPassword();
@@ -67,7 +65,7 @@ public class Client {
    * Establishes a connection to an SSH server containing a channel connected to an SFTP server.
    *
    * @return <code>true</code> on successful connection to the SSH/SFTP server; <code>false</code>
-   *     otherwise.
+   * otherwise.
    */
   public boolean connect() {
     if (createSshConnection() && createSftpChannel()) {
@@ -86,7 +84,7 @@ public class Client {
    * <p>One session can contain multiple channels of various types.
    *
    * @return <code>true</code> on successful creation of session object representing a connection to
-   *     an SSH server; <code>false</code> otherwise.
+   * an SSH server; <code>false</code> otherwise.
    */
   protected boolean createSshConnection() {
     try {
@@ -98,7 +96,7 @@ public class Client {
       session.setConfig(config);
       session.connect(TIMEOUT);
       logger.log(
-          String.format("Establishing a connection for %s@%s...", user.username, user.hostname));
+        String.format("Establishing a connection for %s@%s...", user.username, user.hostname));
       out.println("Establishing a connection...");
     } catch (JSchException e) {
       out.println("Failed to connect to the server");
@@ -113,7 +111,7 @@ public class Client {
    * supports the client side of the SFTP protocol.
    *
    * @return <code>true</code> on creating a channel connected to an SFTP server; <code>false</code>
-   *     otherwise.
+   * otherwise.
    */
   protected boolean createSftpChannel() {
     try {
@@ -145,12 +143,16 @@ public class Client {
     out.println("A log file has been saved to your local Downloads directory");
   }
 
-  /** @return a Channel object connected to an SFTP server. */
+  /**
+   * @return a Channel object connected to an SFTP server.
+   */
   ChannelSftp getChannelSftp() {
     return channelSftp;
   }
 
-  /** @return a Session object representing a connection to an SSH server. */
+  /**
+   * @return a Session object representing a connection to an SSH server.
+   */
   Session getSession() {
     return session;
   }
@@ -159,8 +161,8 @@ public class Client {
    * Lists all directories and files in the user's current local directory.
    *
    * @return <code>true</code> if directories and/or files in the user's current local directory are
-   *     listed; otherwise, return <code>false</code> to indicate the user's current local directory
-   *     is empty.
+   * listed; otherwise, return <code>false</code> to indicate the user's current local directory
+   * is empty.
    */
   boolean displayLocalFiles() {
     logger.log("displayLocalFiles called");
@@ -186,8 +188,8 @@ public class Client {
    * Lists all directories and files in the user's current remote directory.
    *
    * @return <code>true</code> if directories and/or files in the user's current remote directory
-   *     are listed; otherwise, return <code>false</code> to indicate the user's current remote
-   *     directory is empty.
+   * are listed; otherwise, return <code>false</code> to indicate the user's current remote
+   * directory is empty.
    */
   boolean displayRemoteFiles() {
     logger.log("displayRemoteFiles called");
@@ -212,7 +214,9 @@ public class Client {
     return false;
   }
 
-  /** Create a directory on the user's remote machine. */
+  /**
+   * Create a directory on the user's remote machine.
+   */
   void createRemoteDir() {
     logger.log("createRemoteDir called");
     boolean repeat = true;
@@ -264,21 +268,27 @@ public class Client {
     return attrs != null;
   }
 
-  /** Print current working local path */
+  /**
+   * Print current working local path
+   */
   void printLocalWorkingDir() {
     logger.log("printLocalWorkingDir called");
     String lpwd = channelSftp.lpwd();
     out.println("This is your current local working directory: " + lpwd + "\n");
   }
 
-  /** Print current working remote path */
+  /**
+   * Print current working remote path
+   */
   void printRemoteWorkingDir() throws SftpException {
     logger.log("printRemoteWorkingDir called");
     String pwd = channelSftp.pwd();
     out.println("This is your current remote working directory: " + pwd + "\n");
   }
 
-  /** Wrapper for changing current working local path */
+  /**
+   * Wrapper for changing current working local path
+   */
   void changeLocalWorkingDir() {
     logger.log("changeLocalWorkingDir called");
     String newDir;
@@ -309,7 +319,9 @@ public class Client {
     return pass;
   }
 
-  /** Change current working remote path */
+  /**
+   * Change current working remote path
+   */
   void changeRemoteWorkingDir() throws SftpException {
     logger.log("changeRemoteWorkingDir called");
     String newDir;
@@ -402,7 +414,9 @@ public class Client {
     }
   }
 
-  /** Rename local files/directories */
+  /**
+   * Rename local files/directories
+   */
   void renameLocal() {
     boolean repeat = true;
     String input;
@@ -413,7 +427,7 @@ public class Client {
         out.println("Enter the original local file name (e.g., file.txt or directoryName): ");
         oldFilename = scanner.nextLine();
         if (oldFilename.equals("")) // check for empty input
-        System.err.println("You did not enter a file name.");
+          System.err.println("You did not enter a file name.");
       }
       File originalFile = new File(channelSftp.lpwd() + "/" + oldFilename);
       // get the new file name
@@ -422,7 +436,7 @@ public class Client {
         out.println("Enter the new local file name (e.g., file.txt or directoryName): ");
         newFilename = scanner.nextLine();
         if (newFilename.equals("")) // check for empty input
-        System.err.println(("You did not enter a file name."));
+          System.err.println(("You did not enter a file name."));
       }
       File renamedFile = new File(channelSftp.lpwd() + "/" + newFilename);
       // check for a duplicate file/directory name
@@ -447,52 +461,51 @@ public class Client {
     }
   }
 
-  /** Rename file/directory on remote server */
+  /**
+   * Rename file/directory on remote server
+   */
   void renameRemote() throws SftpException {
     boolean repeat = true;
     String input;
     SftpATTRS attrs = null;
-    while (repeat) {
-      // get original file name
-      String oldFilename = "";
-      while (oldFilename.equals("")) {
-        out.println("Enter the original remote file name (e.g., file.txt or directoryName): ");
-        oldFilename = scanner.nextLine();
-        if (oldFilename.equals("")) // check for empty input
+    // get original file name
+    String oldFilename = "";
+    while (oldFilename.equals("")) {
+      out.println("Enter the original remote file name (e.g., file.txt or directoryName): ");
+      oldFilename = scanner.nextLine();
+      if (oldFilename.equals("")) // check for empty input
         System.err.println("You did not enter a file name.");
-      }
-      String oldFilePath = channelSftp.pwd() + "/" + oldFilename;
-      // get the new file name
-      String newFilename = "";
-      while (newFilename.equals("")) {
-        out.println("Enter the new remote file name (e.g., file.txt or directoryName): ");
-        newFilename = scanner.nextLine();
-        if (newFilename.equals("")) // check for empty input
+    }
+    String oldFilePath = channelSftp.pwd() + "/" + oldFilename;
+    // get the new file name
+    String newFilename = "";
+    while (newFilename.equals("")) {
+      out.println("Enter the new remote file name (e.g., file.txt or directoryName): ");
+      newFilename = scanner.nextLine();
+      if (newFilename.equals("")) // check for empty input
         System.err.println(("You did not enter a file name."));
-      }
-      String newFilePath = channelSftp.pwd() + "/" + newFilename;
+    }
+    String newFilePath = channelSftp.pwd() + "/" + newFilename;
+    try {
+      attrs = channelSftp.stat(newFilePath);
+    } catch (Exception e) {
+      out.println();
+    }
+    boolean rename = false;
+    if (attrs != null) {
+      out.println("A file or directory by this name already exists. Overwrite? (yes/no)");
+      input = scanner.next();
+      attrs = null;
+      if (input.equalsIgnoreCase("yes") || (input.equalsIgnoreCase("y"))) rename = true;
+    } else {
+      rename = true;
+    }
+    if (rename) {
       try {
-        attrs = channelSftp.stat(newFilePath);
-      } catch (Exception e) {
-        out.println();
-      }
-      boolean rename = false;
-      if (attrs != null) {
-        out.println("A file or directory by this name already exists. Overwrite? (yes/no)");
-        input = scanner.next();
-        attrs = null;
-        if (input.equalsIgnoreCase("yes") || (input.equalsIgnoreCase("y"))) rename = true;
-      } else {
-        rename = true;
-      }
-      if (rename) {
-        try {
-          channelSftp.rename(oldFilePath, newFilePath);
-          out.println(oldFilename + " has been renamed to: " + newFilename);
-        } catch (SftpException e) {
-          out.println("Error: rename unsuccessful.");
-        }
-        repeat = false;
+        channelSftp.rename(oldFilePath, newFilePath);
+        out.println(oldFilename + " has been renamed to: " + newFilename);
+      } catch (SftpException e) {
+        out.println("Error: rename unsuccessful.");
       }
     }
   }
@@ -530,7 +543,9 @@ public class Client {
     }
   }
 
-  /** Displays log history to user and logs being invoked */
+  /**
+   * Displays log history to user and logs being invoked
+   */
   void displayLogHistory() {
     logger.display();
     logger.log("displayLogHistory called");

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -10,7 +10,6 @@ import java.util.Vector;
 
 import static java.lang.System.err;
 import static java.lang.System.out;
-import static java.lang.System.err;
 
 /**
  * Represents the SSH File Transfer Protocol (SFTP) client. Supports the full security and
@@ -19,8 +18,6 @@ import static java.lang.System.err;
 public class Client {
   private static final int TIMEOUT = 60_000; // Set default timeout to 60 seconds to accommodate slow servers
   private Scanner scanner = new Scanner(System.in);
-  private static final int TIMEOUT =
-      60_000; // Set default timeout to 60 seconds to accommodate slow servers
   private User user;
   private JSch jsch;
   private Session session;
@@ -473,44 +470,29 @@ public class Client {
   void renameRemoteFile(String filename) throws SftpException {
     logger.log("renameRemoteFile called");
 
-    String input;
-    SftpATTRS attrs = null;
-
-    // get original file name
-    String oldFilename = "";
-    while (oldFilename.equals("")) {
-      out.println("Enter the original remote file name (e.g., file.txt or directoryName): ");
-      oldFilename = scanner.nextLine();
-      if (oldFilename.equals("")) // check for empty input
-        System.err.println("You did not enter a file name.");
-    }
     String oldFilePath = channelSftp.pwd() + "/" + oldFilename;
-    // get the new file name
-    String newFilename = "";
-    while (newFilename.equals("")) {
-      out.println("Enter the new remote file name (e.g., file.txt or directoryName): ");
-      newFilename = scanner.nextLine();
-      if (newFilename.equals("")) // check for empty input
-        System.err.println(("You did not enter a file name."));
-    }
     String newFilePath = channelSftp.pwd() + "/" + newFilename;
-    try {
-      attrs = channelSftp.stat(newFilePath);
-    } catch (Exception e) {
-      out.println();
-    }
     boolean rename = false;
-    if (attrs != null) {
+
+    SftpATTRS fileAttributes = null;
+
+    try {
+      fileAttributes = channelSftp.stat(newFilePath);
+    } catch (Exception e) {
+      out.println("Error retrieving file attributes.");
+    }
+
+    if (fileAttributes != null) {
       out.println("A file or directory by this name already exists. Overwrite? (yes/no)");
-      input = scanner.next();
-      if (input.equalsIgnoreCase("yes")) rename = true;
+      if (scanner.next().equalsIgnoreCase("yes")) rename = true;
     } else {
       rename = true;
     }
+
     if (rename) {
       try {
         channelSftp.rename(oldFilePath, newFilePath);
-        out.println(oldFilename + " has been renamed to: " + newFilename);
+        out.println(oldFilename + " has been renamed: " + newFilename);
       } catch (SftpException e) {
         out.println("Error: rename unsuccessful.");
       }

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -421,22 +421,22 @@ public class Client {
     boolean repeat = true;
     String input;
     while (repeat) {
-      // get original file name
+      // get original filename
       String oldFilename = "";
       while (oldFilename.equals("")) {
-        out.println("Enter the original local file name (e.g., file.txt or directoryName): ");
+        out.println("Enter the original local filename (e.g., file.txt or directoryName): ");
         oldFilename = scanner.nextLine();
         if (oldFilename.equals("")) // check for empty input
-          System.err.println("You did not enter a file name.");
+          System.err.println("You did not enter a filename.");
       }
       File originalFile = new File(channelSftp.lpwd() + "/" + oldFilename);
-      // get the new file name
+      // get the new filename
       String newFilename = "";
       while (newFilename.equals("")) {
-        out.println("Enter the new local file name (e.g., file.txt or directoryName): ");
+        out.println("Enter the new local filename (e.g., file.txt or directoryName): ");
         newFilename = scanner.nextLine();
         if (newFilename.equals("")) // check for empty input
-          System.err.println(("You did not enter a file name."));
+          System.err.println(("You did not enter a filename."));
       }
       File renamedFile = new File(channelSftp.lpwd() + "/" + newFilename);
       // check for a duplicate file/directory name

--- a/src/main/java/edu/pdx/cs/sftp/Main.java
+++ b/src/main/java/edu/pdx/cs/sftp/Main.java
@@ -118,6 +118,7 @@ public class Main {
    * @throws SftpException from JSCH
    */
   private static void rename(Client client) throws SftpException {
+    Scanner scanner = new Scanner(System.in);
     var menu = new Menu();
     int opt;
 
@@ -149,7 +150,11 @@ public class Main {
           System.out.println("Rename remote directory/file...");
           client.displayRemoteFiles();
           try {
-            client.renameRemote();
+            out.println("Please enter the original name of the file to rename.");
+            String oldFilename = scanner.nextLine();
+            out.println("Please enter the new name of the file to rename.");
+            String newFilename = scanner.nextLine();
+            client.renameRemoteFile(oldFilename, newFilename);
           } catch (SftpException e) {
             out.println("Error renaming file");
           }

--- a/src/test/java/edu/pdx/cs/sftp/ClientTest.java
+++ b/src/test/java/edu/pdx/cs/sftp/ClientTest.java
@@ -41,7 +41,9 @@ public class ClientTest {
     assertThat(client.connect(), equalTo(false));
   }
 
-  /** Trying to upload a file should result in an error. Expects an SftpException. */
+  /**
+   * Trying to upload a file should result in an error. Expects an SftpException.
+   */
   @Test(expected = SftpException.class)
   public void uploadFakeFile_expectsSftpException() throws SftpException {
     Client client = new Client("fakeUsername", "fakePassword", "fakeHostname");
@@ -54,7 +56,9 @@ public class ClientTest {
     client.uploadFile("This is not a file");
   }
 
-  /** Should throw exception when file not found when upload attempted */
+  /**
+   * Should throw exception when file not found when upload attempted
+   */
   @Test(expected = SftpException.class)
   public void uploadFile_expectsSftpException_NoSuchFile() throws SftpException {
     String fileName = "MissingTextFile.txt";
@@ -68,7 +72,9 @@ public class ClientTest {
     client.uploadFile(fileName);
   }
 
-  /** Asserts uploaded file exists */
+  /**
+   * Asserts uploaded file exists
+   */
   @Test
   public void uploadFile_assertsFileExists() throws SftpException, IOException {
     String fileName = "testfile.txt";
@@ -93,7 +99,9 @@ public class ClientTest {
     else System.out.println("Could not delete testfile.txt from local");
   }
 
-  /** Asserts uploaded file was deleted. stat() throws exception if filename is not found. */
+  /**
+   * Asserts uploaded file was deleted. stat() throws exception if filename is not found.
+   */
   @Test(expected = SftpException.class)
   public void deleteFile_expectsSftpException() throws SftpException {
     String fileName = "testfile.txt";
@@ -138,7 +146,9 @@ public class ClientTest {
     }
   }
 
-  /** Test whether a file is uploaded correctly. */
+  /**
+   * Test whether a file is uploaded correctly.
+   */
   @Test
   public void downloadFile() {
     String fileName = "testfile.txt";
@@ -175,7 +185,9 @@ public class ClientTest {
     }
   }
 
-  /** Asserts whether a remote directory is created */
+  /**
+   * Asserts whether a remote directory is created
+   */
   @Test
   public void createRemoteDir_assertsDirExists() throws SftpException {
     Client client = new Client(username, password, hostname);
@@ -190,7 +202,9 @@ public class ClientTest {
     client.getChannelSftp().rmdir(dirName); // clean up
   }
 
-  /** Asserts whether a local directory is created */
+  /**
+   * Asserts whether a local directory is created
+   */
   @Test
   public void createLocalDir_assertsDirExists() {
     Client client = new Client(username, password, hostname);
@@ -204,10 +218,12 @@ public class ClientTest {
     assertThat(newDir.exists(), equalTo(true));
     System.out.println(dirName + " was created successfully");
     if (newDir.delete()) // clean up
-    System.out.println(dirName + " was deleted");
+      System.out.println(dirName + " was deleted");
   }
 
-  /** Asserts whether a local directory was changed Also inherently tests printLocalWorkingDir() */
+  /**
+   * Asserts whether a local directory was changed Also inherently tests printLocalWorkingDir()
+   */
   @Test
   public void changeLocalDir_assertsDirChanged() {
     boolean pass = false;
@@ -227,8 +243,8 @@ public class ClientTest {
       output.reset();
       client.printLocalWorkingDir();
       assertThat(
-          output.toString().contains(newLocalPath),
-          equalTo(false)); // assert current path is not newDir
+        output.toString().contains(newLocalPath),
+        equalTo(false)); // assert current path is not newDir
       client.changeLocalWorkingDir(newLocalPath); // change path to newDir
       output.reset();
       client.printLocalWorkingDir();
@@ -238,7 +254,7 @@ public class ClientTest {
       if (!newDir.delete()) System.out.println("Error deleting testing directory");
       else {
         System.out.println(
-            "Path successfully changed to new dir. New dir has been deleted and path is reset.");
+          "Path successfully changed to new dir. New dir has been deleted and path is reset.");
         pass = true;
       }
     } else {
@@ -269,8 +285,8 @@ public class ClientTest {
       output.reset();
       client.printRemoteWorkingDir();
       assertThat(
-          output.toString().contains(newRemotePath),
-          equalTo(false)); // assert current path is not newDir
+        output.toString().contains(newRemotePath),
+        equalTo(false)); // assert current path is not newDir
       client.changeRemoteWorkingDir(newRemotePath); // change path to newDir
       output.reset();
       client.printRemoteWorkingDir();
@@ -280,7 +296,7 @@ public class ClientTest {
 
       client.getChannelSftp().rmdir(newRemotePath);
       System.out.println(
-          "Path successfully changed to new dir. New dir has been deleted and path is reset.");
+        "Path successfully changed to new dir. New dir has been deleted and path is reset.");
       pass = true;
     } else {
       System.setOut(stdout);


### PR DESCRIPTION
Changes implemented by this PR:
- Reformat spacing as suggested by IntelliJ IDE
- Rename all instances of `file name` to `filename`
- Remove commented out/unused method `remoteExec()`
- Rename method from `renameRemote()` to `renameRemoteFile()`
- Move user input of filename to `Main.java` to match other methods
- Rename method variables to more descriptive names
- Improve javadoc comment including a better method description and info on params and thrown exception