### PR TITLE
Rename local method

### DIFF
--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -420,7 +420,7 @@ public class Client {
   /**
    * Rename local files/directories
    */
-  void renameLocal() {
+  void renameLocalFile(String oldFilename, String newFilename) {
     boolean repeat = true;
     String input;
     while (repeat) {

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -421,6 +421,8 @@ public class Client {
    * Rename local files/directories
    */
   void renameLocalFile(String oldFilename, String newFilename) {
+    logger.log("renameLocalFile called");
+
     boolean repeat = true;
     String input;
     while (repeat) {

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -423,45 +423,22 @@ public class Client {
   void renameLocalFile(String oldFilename, String newFilename) {
     logger.log("renameLocalFile called");
 
-    boolean repeat = true;
-    String input;
-    while (repeat) {
-      // get original filename
-      String oldFilename = "";
-      while (oldFilename.equals("")) {
-        out.println("Enter the original local filename (e.g., file.txt or directoryName): ");
-        oldFilename = scanner.nextLine();
-        if (oldFilename.equals("")) // check for empty input
-          System.err.println("You did not enter a filename.");
-      }
-      File originalFile = new File(channelSftp.lpwd() + "/" + oldFilename);
-      // get the new filename
-      String newFilename = "";
-      while (newFilename.equals("")) {
-        out.println("Enter the new local filename (e.g., file.txt or directoryName): ");
-        newFilename = scanner.nextLine();
-        if (newFilename.equals("")) // check for empty input
-          System.err.println(("You did not enter a filename."));
-      }
-      File renamedFile = new File(channelSftp.lpwd() + "/" + newFilename);
-      // check for a duplicate file/directory name
-      boolean rename = false;
-      if (renamedFile.exists()) {
-        out.println("A file or directory by this name already exists. Overwrite? (yes/no)");
-        input = scanner.next();
-        if ((input.equalsIgnoreCase("yes") || (input.equalsIgnoreCase("y")))) {
-          rename = true;
-        }
+    File oldFilepath = new File(channelSftp.lpwd() + "/" + oldFilename);
+    File newFilepath = new File(channelSftp.lpwd() + "/" + newFilename);
+    boolean rename = false;
+
+    if (newFilepath.exists()) {
+      out.println("A file or directory by this name already exists. Overwrite? (yes/no)");
+      if (scanner.next().equalsIgnoreCase("yes")) rename = true;
+    } else {
+      rename = true;
+    }
+
+    if (rename) {
+      if (oldFilepath.renameTo(newFilepath)) {
+        out.println(oldFilename + " has been renamed to: " + newFilename + "\n");
       } else {
-        rename = true;
-      }
-      if (rename) {
-        if (originalFile.renameTo(renamedFile)) {
-          out.println(oldFilename + " has been renamed to: " + newFilename + "\n");
-        } else {
-          out.println("Error: rename unsuccessful.\n");
-        }
-        repeat = false;
+        out.println("Error: rename unsuccessful.\n");
       }
     }
   }

--- a/src/main/java/edu/pdx/cs/sftp/Client.java
+++ b/src/main/java/edu/pdx/cs/sftp/Client.java
@@ -418,7 +418,11 @@ public class Client {
   }
 
   /**
-   * Rename local files/directories
+   * Renames the specified file on the local directory to the provided new name. If a file by the
+   * same new name exists, the user is prompted to determine whether or not to overwrite it.
+   *
+   * @param oldFilename the name of the file to be renamed.
+   * @param newFilename the new name of the file to be renamed.
    */
   void renameLocalFile(String oldFilename, String newFilename) {
     logger.log("renameLocalFile called");

--- a/src/main/java/edu/pdx/cs/sftp/Main.java
+++ b/src/main/java/edu/pdx/cs/sftp/Main.java
@@ -144,16 +144,20 @@ public class Main {
         case 5:
           System.out.println("Rename local directory/file...");
           client.displayLocalFiles();
-          client.renameLocal();
+          out.println("Please enter the original name of the file to rename.");
+          String oldFilename = scanner.nextLine();
+          out.println("Please enter the new name of the file to rename.");
+          String newFilename = scanner.nextLine();
+          client.renameLocalFile(oldFilename, newFilename);
           break;
         case 6:
           System.out.println("Rename remote directory/file...");
           client.displayRemoteFiles();
           try {
             out.println("Please enter the original name of the file to rename.");
-            String oldFilename = scanner.nextLine();
+            oldFilename = scanner.nextLine();
             out.println("Please enter the new name of the file to rename.");
-            String newFilename = scanner.nextLine();
+            newFilename = scanner.nextLine();
             client.renameRemoteFile(oldFilename, newFilename);
           } catch (SftpException e) {
             out.println("Error renaming file");


### PR DESCRIPTION
This PR implements the following changes:
- Improves javadoc comment by making it more descriptive, including information on the parameters
- Changes the variable names within the method
- Refactors method by moving the user input to `Main.java` to match other class methods.
- Refactors method by streamlining its logic and following the pattern used in `renameRemoteFile()`
- Renames method from `renameLocal()` to `renameLocalFile()`